### PR TITLE
[STRAITSX-4334] PBM contract updated metadata

### DIFF
--- a/contracts/IPBM.sol
+++ b/contracts/IPBM.sol
@@ -16,6 +16,7 @@ interface IPBM {
     /// @param spotAmount Amount of the underlying ERC-20 tokens the PBM type wraps around
     /// @param tokenExpiry The expiry date (in epoch) for this particular PBM token type 
     /// @param tokenURI the URI (returns json) of PBM type that will follows the Opensea NFT metadata standard
+    /// @param postExpiryURI the URI (returns json) of expired PBM type that will follows the Opensea NFT metadata standard
     /**
     * example response of token URI, ref : https://docs.opensea.io/docs/metadata-standards
     * {
@@ -30,7 +31,7 @@ interface IPBM {
     *     ]
     * }
      */
-    function createPBMTokenType(string memory companyName, uint256 spotAmount, uint256 tokenExpiry,address creator, string memory tokenURI) external;  
+    function createPBMTokenType(string memory companyName, uint256 spotAmount, uint256 tokenExpiry,address creator, string memory tokenURI, string memory postExpiryURI) external;
 
     /// @notice Creates new PBM copies ( ERC1155 NFT ) of an existing PBM token type after ensuring it is backed by the necessary value of the underlying ERC-20 tokens 
     /// @param tokenId The identifier of the PBM token type

--- a/contracts/IPBMTokenManager.sol
+++ b/contracts/IPBMTokenManager.sol
@@ -48,13 +48,15 @@ interface IPBMTokenManager {
     /// @param tokenExpiry The expiry date (in epoch) of th PBM type
     /// @param creator The address of the account that creates the PBM type
     /// @param tokenURI the URI containting the metadata (opensea standard for ERC1155) for the  PBM type
+    /// @param postExpiryURI the URI containting the metadata (opensea standard for ERC1155) for the expired PBM type
     /// @param contractExpiry the expiry time (in epoch) for the overall PBM contract
     function createTokenType(
         string memory companyName, 
         uint256 spotAmount, 
         uint256 tokenExpiry, 
         address creator,
-        string memory tokenURI, 
+        string memory tokenURI,
+        string memory postExpiryURI,
         uint256 contractExpiry
     ) external ; 
 

--- a/contracts/PBM.sol
+++ b/contracts/PBM.sol
@@ -25,8 +25,8 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
     // time of expiry ( epoch )
     uint256 public contractExpiry ; 
 
-    constructor(string memory _uriPostExpiry) ERC1155("") {
-        pbmTokenManager = address(new PBMTokenManager(_uriPostExpiry)) ; 
+    constructor() ERC1155("") {
+        pbmTokenManager = address(new PBMTokenManager()) ;
     }
 
     function initialise(address _spotToken, uint256 _expiry, address _pbmAddressList)
@@ -54,12 +54,12 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
      * - `tokenExpiry` must be less than contract expiry
      * - `amount` should not be 0
      */
-    function createPBMTokenType(string memory companyName, uint256 spotAmount, uint256 tokenExpiry,address creator, string memory tokenURI) 
+    function createPBMTokenType(string memory companyName, uint256 spotAmount, uint256 tokenExpiry,address creator, string memory tokenURI, string memory postExpiryURI)
     external 
     override
     onlyOwner 
     {        
-        PBMTokenManager(pbmTokenManager).createTokenType(companyName, spotAmount, tokenExpiry, creator,  tokenURI, contractExpiry);
+        PBMTokenManager(pbmTokenManager).createTokenType(companyName, spotAmount, tokenExpiry, creator,  tokenURI, postExpiryURI, contractExpiry);
     }
 
     /**

--- a/contracts/PBMTokenManager.sol
+++ b/contracts/PBMTokenManager.sol
@@ -20,18 +20,14 @@ contract PBMTokenManager is Ownable, IPBMTokenManager, NoDelegateCall {
         uint256 expiry ; 
         address creator ; 
         uint256 balanceSupply ; 
-        string uri ; 
+        string uri ;
+        string postExpiryURI;
     }
-
-    // URI for tokens after expiry
-    string  internal  URIPostExpiry ; 
 
     // mapping of token ids to token details
     mapping (uint256 => TokenConfig) internal tokenTypes ; 
 
-    constructor(string memory _uriPostExpiry){
-        URIPostExpiry = _uriPostExpiry ; 
-    }
+    constructor(){}
 
     /**
      * @dev See {IPBMTokenManager-createPBMTokenType}.
@@ -43,7 +39,7 @@ contract PBMTokenManager is Ownable, IPBMTokenManager, NoDelegateCall {
      * - token expiry must be less than contract expiry
      * - `amount` should not be 0
      */ 
-    function createTokenType(string memory companyName, uint256 spotAmount, uint256 tokenExpiry, address creator, string memory tokenURI, uint256 contractExpiry) 
+    function createTokenType(string memory companyName, uint256 spotAmount, uint256 tokenExpiry, address creator, string memory tokenURI, string memory postExpiryURI,uint256 contractExpiry)
     external 
     override 
     onlyOwner
@@ -59,7 +55,8 @@ contract PBMTokenManager is Ownable, IPBMTokenManager, NoDelegateCall {
         tokenTypes[tokenTypeCount].expiry = tokenExpiry ; 
         tokenTypes[tokenTypeCount].creator = creator ; 
         tokenTypes[tokenTypeCount].balanceSupply = 0 ; 
-        tokenTypes[tokenTypeCount].uri = tokenURI ; 
+        tokenTypes[tokenTypeCount].uri = tokenURI ;
+        tokenTypes[tokenTypeCount].postExpiryURI = postExpiryURI ;
 
         emit NewPBMTypeCreated(tokenTypeCount, tokenName, spotAmount, tokenExpiry, creator);
         tokenTypeCount += 1 ;
@@ -136,7 +133,7 @@ contract PBMTokenManager is Ownable, IPBMTokenManager, NoDelegateCall {
     returns (string memory)
     {
         if (block.timestamp >= tokenTypes[tokenId].expiry){
-            return URIPostExpiry ; 
+            return tokenTypes[tokenId].postExpiryURI ;
         }
         return tokenTypes[tokenId].uri ; 
     }

--- a/migrations/2_deploy_spot.js
+++ b/migrations/2_deploy_spot.js
@@ -2,5 +2,5 @@ const Spot = artifacts.require("Spot") ;
 
 module.exports = async function (deployer) {
     // comment out if you don't need to deploy an ERC-20 token. 
-    //deployer.deploy(Spot) ; 
+    // deployer.deploy(Spot) ;
 }

--- a/migrations/3_deploy_pbm.js
+++ b/migrations/3_deploy_pbm.js
@@ -5,27 +5,30 @@ const PBMAddr = artifacts.require("PBMAddressList") ;
 module.exports = async function (deployer, network, accounts) {
 
     // deploying PBM addr
-    //await deployer.deploy(PBMAddr) ; 
+    await deployer.deploy(PBMAddr) ;
     const pbmAddr = await PBMAddr.deployed(); 
     await new Promise(r => setTimeout(r, 5000)); 
     console.log("Pbm address manager is : ", pbmAddr.address) ; 
 
 
-    const expiryDate = 1667663999; // Saturday, 5 November 2022 23:59:59 GMT+08:00
+    // const expiryDate = 1667663999; // Saturday, 5 November 2022 23:59:59 GMT+08:00
     // if you'd prefer to set an expiry a few days from now, UNCOMMENT the code below, and comment the above line.
-    /*
-    ** currentDate = new Date()
-    ** currentEpoch = Math.floor(currentDate/1000) ; 
-    ** const expiryDate = currentEpoch + 200000; 
-    */
-    await deployer.deploy(PBM, "https://harlequin-eldest-leopard-210.mypinata.cloud/ipfs/QmRTr97TBWcp9MTeyNcDn7GseaxWDaKUBiokDyPePS4wnh/TC%202022_expiry.json") ; 
+
+    // currentDate = new Date()
+    // currentEpoch = Math.floor(currentDate/1000) ;
+    // const expiryDate = currentEpoch + 200000;
+    const expiryDate = 1716469200; // Tue May 23 2024 21:00:00 GMT+0800 (Taipei Standard Time) 2024-05-23T21:00:00+08:00
+
+
+    await deployer.deploy(PBM) ;
     pbm = await PBM.deployed(); 
     console.log("pbm addresss  : ", pbm.address)
 
-    //const spot = await Spot.deployed() ; 
-    //const address = spot.address; 
+    // const spot = await Spot.deployed() ;
+    // const address = spot.address;
     // If you are deploying to a public testnet/mainnet , and want to use an existing ERC-20 contract, COMMENT OUT the lines above, and UNCOMMENT the code below
-    const address = "0xDC3326e71D45186F113a2F448984CA0e8D201995" ;     // Polygon XSGD address 
+    // const address = "0xDC3326e71D45186F113a2F448984CA0e8D201995" ;     // Polygon XSGD address
+    const address = "0x16e28369bc318636abbf6cb1035da77ffbf4a3bc" ;     // mumbai XSGD address
     await pbm.initialise(address, expiryDate, pbmAddr.address);    
     await new Promise(r => setTimeout(r, 5000));
 }

--- a/migrations/4_airdrop_pbms.js
+++ b/migrations/4_airdrop_pbms.js
@@ -46,5 +46,7 @@ module.exports = async function (deployer,network, accounts) {
     await pbm.batchMint([0,1,2], [10,10,10], "0x8CC4D23D8556Fdb5875F17b6d6D7149380F24D93") ;
     // airdrop to circle test wallet
     await pbm.batchMint([0,1,2], [10,10,10], "0x281F397c5a5a6E9BE42255b01EfDf8b42F0Cd179") ;
+    // airdrop to grab wallet
+    await pbm.batchMint([0,1,2], [10,10,5], "0xd0b72a553d2c57f7997ba420a758c7a0fad92eef") ;
     console.log("PBM created and minted") ; 
 }

--- a/migrations/4_airdrop_pbms.js
+++ b/migrations/4_airdrop_pbms.js
@@ -7,32 +7,44 @@ module.exports = async function (deployer,network, accounts) {
     // Migration to create and deploy PBM token types
     // Commented our since this is not required by all. UNCOMMENT and use as necessary
 
-    // //const spot = await Spot.deployed() ; // UNCOMMENT  if you are using the ERC20 deployed in the second migration 
+    // const spot = await Spot.deployed() ; // UNCOMMENT  if you are using the ERC20 deployed in the second migration
     const pbm = await PBM.deployed(); 
 
-    // // currentDate = new Date()
-    // // currentEpoch = Math.floor(currentDate/1000) ; 
-    // //var targetEpoch = currentEpoch+10000000;  // Expiry is set to 115 days, 17 hours, 46 minutes and 40 seconds
-    var targetEpoch = 1667577599; // Friday, 4 November 2022 23:59:59 GMT+08:00
+    // currentDate = new Date()
+    // currentEpoch = Math.floor(currentDate/1000) ;
+    // var targetEpoch = currentEpoch+100000;  // Expiry is set to 115 days, 17 hours, 46 minutes and 40 seconds
+    // var targetEpoch = 1684843200; // Tuesday, May 23, 2023 8:00:00 PM GMT+08:00 2023-05-23T20:00:00+08:00
+    var targetEpoch = 1716469200; // Tue May 23 2024 21:00:00 GMT+0800 (Taipei Standard Time) 2024-05-23T21:00:00+08:00
+    var may31Epoch = 1685538000; // Wednesday, May 31, 2023 21:00:00 GMT+08:00 2023-05-31T21:00:00+08:00
 
 
     // // Increasing allowance on deployed ERC20 tokens. UNCOMMENT below if you are using the ERC20 deployed in the second migration
-    // //await spot.mint(accounts[0], 100 ) ; 
-    // //console.log("minted spot") ; 
+    // await spot.mint(accounts[0], 100000000000 ) ;
+    // console.log("minted spot") ;
 
-    // creating new PBM token types
-    await pbm.createPBMTokenType("Temasek", 1000000, targetEpoch, accounts[0], "https://harlequin-eldest-leopard-210.mypinata.cloud/ipfs/QmRTr97TBWcp9MTeyNcDn7GseaxWDaKUBiokDyPePS4wnh/TC%202022_$1.json" ) ; 
-    console.log("PBM Token type 1 created") ; 
+    // creating new PBM token types with aligned metadata
+    await pbm.createPBMTokenType("Grab1-sample", 1000000, targetEpoch, accounts[0], "https://gateway.pinata.cloud/ipfs/QmSQedXTQeYskLthumBtD9vh4DFJyrWVfjQXBQTDB9tPCw", "https://gateway.pinata.cloud/ipfs/QmXCGMvSF5VuYmbJMJrngoPAr2pEeeBk7LivccsSxm9qKS" ) ;
+    console.log("PBM Token type 1 created") ;
     await new Promise(r => setTimeout(r, 5000)); // UNCOMMENT to prevent rpc rate limiting if you are on free version
 
-    await pbm.createPBMTokenType("Temasek", 9000000, targetEpoch, accounts[0], "https://harlequin-eldest-leopard-210.mypinata.cloud/ipfs/QmRTr97TBWcp9MTeyNcDn7GseaxWDaKUBiokDyPePS4wnh/TC%202022_$9.json" ) ;
-    console.log("PBM Token type 2 created") ; 
+    await pbm.createPBMTokenType("Grab2-sample", 2000000, targetEpoch, accounts[0], "https://gateway.pinata.cloud/ipfs/QmWMM6AfC25Cu2SVJwx8xMmkc9g6aWjoEw1G6u6jFzqd35", "https://gateway.pinata.cloud/ipfs/QmXKQWs6BoGfrooWZWmcF13gu38etP7pabU4x9DegdtNvj" ) ;
+    console.log("PBM Token type 2 created") ;
     await new Promise(r => setTimeout(r, 5000)); // UNCOMMENT to prevent rpc rate limiting if you are on free version
 
-    // // Increasing allowance on deployed ERC20 tokens. UNCOMMENT below if you are using the ERC20 deployed in the second migration
-    // //await spot.increaseAllowance(pbm.address, 100) ; 
-    // //await new Promise(r => setTimeout(r, 5000)); // UNCOMMENT to prevent rpc rate limiting if you are on free version
+    await pbm.createPBMTokenType("Grab3-sample", 3000000, may31Epoch, accounts[0], "https://gateway.pinata.cloud/ipfs/QmPqd4rW5YWmErDUUxFQK3iLn8h632egizkYHYasY7swX6", "https://gateway.pinata.cloud/ipfs/QmUiUpRkE17jBLFsphxgvfqsNaF46YNeSzWSkSc6ERC2We" ) ;
+    console.log("PBM Token type 3 created") ;
+    await new Promise(r => setTimeout(r, 5000)); // UNCOMMENT to prevent rpc rate limiting if you are on free version
 
-    await pbm.batchMint([0,1], [1,1], "0x276f35cCF9f6F313c7b34Df558c2DdC56045885c") ; 
+
+    // Increasing allowance on deployed ERC20 tokens. UNCOMMENT below if you are using the ERC20 deployed in the second migration
+    // await spot.increaseAllowance(pbm.address, 1000000000) ;
+    // await new Promise(r => setTimeout(r, 5000)); // UNCOMMENT to prevent rpc rate limiting if you are on free version
+
+    // Increasing allowance on mumbai XSGD
+    const spot = await Spot.at("0x16e28369bc318636abbf6cb1035da77ffbf4a3bc"); // XSGD deployed on mumbai
+    await spot.increaseAllowance(pbm.address, 10000000000) ;
+    await pbm.batchMint([0,1,2], [10,10,10], "0x8CC4D23D8556Fdb5875F17b6d6D7149380F24D93") ;
+    // airdrop to circle test wallet
+    await pbm.batchMint([0,1,2], [10,10,10], "0x281F397c5a5a6E9BE42255b01EfDf8b42F0Cd179") ;
     console.log("PBM created and minted") ; 
 }


### PR DESCRIPTION
[Context]
- Aligned with Grab to add a IssueValue field to the metadata for each PBM token.

[Approach]
- Update PBM & PBMTokenManager Contract to add the postExpiryURI to the tokenConfig.
- Remove expiry uri in the constructor cause post expiry metadata now unique to each token type.
- Update PBM & PBMTokenManager Contract to pass in the postExpiryURI when creating new token types.
- Created and minted test PBM tokens to circle test wallet.

[References]
- PBM mumbai address: [0xD6A39Ea66EEC7dff0F95B6415fE7B9b5Dcd13609](https://mumbai.polygonscan.com/address/0xd6a39ea66eec7dff0f95b6415fe7b9b5dcd13609)
- deployer address: 0x8CC4D23D8556Fdb5875F17b6d6D7149380F24D93
- test merchant address: 0x5a6bb5b6c5fb42413b253e3b7a03a5c2cecc4ba7
- test non merchat address: 0x1d208683d4aff66da1701e972fdf79355b696da8
- circle test address: 0x281F397c5a5a6E9BE42255b01EfDf8b42F0Cd179
