### PR TITLE
[STRAITSX-4634] set approval for all for pbm owners

### DIFF
--- a/Pilot5SFFNov2023/abi/PBM.json
+++ b/Pilot5SFFNov2023/abi/PBM.json
@@ -786,6 +786,47 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "pbmOwners",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAllForPBMOwners",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "whitelisted",
+        "type": "bool"
+      }
+    ],
+    "name": "setWhitelistApprover",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "spotToken",
     "outputs": [

--- a/Pilot5SFFNov2023/abi/PBM.json
+++ b/Pilot5SFFNov2023/abi/PBM.json
@@ -339,6 +339,29 @@
   {
     "inputs": [
       {
+        "internalType": "address[]",
+        "name": "pbmOwners",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "batchSetApprovalForAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "user",
         "type": "address"
@@ -781,29 +804,6 @@
       }
     ],
     "name": "setApprovalForAll",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "pbmOwners",
-        "type": "address[]"
-      },
-      {
-        "internalType": "address",
-        "name": "operator",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "approved",
-        "type": "bool"
-      }
-    ],
-    "name": "setApprovalForAllForPBMOwners",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/Pilot5SFFNov2023/contracts/PBM.sol
+++ b/Pilot5SFFNov2023/contracts/PBM.sol
@@ -395,20 +395,20 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
     }
 
     /**
-     * @dev setApprovalForAllForPBMOwners for a list of PBM owners
+     * @dev batchSetApprovalForAll for a list of PBM owners
      *
      * Requirements:
      *
      * - caller should either be the contract owner or whitelisted approver
      */
-    function setApprovalForAllForPBMOwners(
+    function batchSetApprovalForAll(
         address[] memory pbmOwners,
         address operator,
         bool approved
     ) public whenNotPaused {
         require(
             _msgSender() == owner() || _approverWhitelist[_msgSender()],
-            "PBM: Only contract owner or whitelisted operator allowed to set approval"
+            "PBM: Only contract owner or whitelisted approver allowed to set approval"
         );
         for (uint256 i = 0; i < pbmOwners.length; i++) {
             _setApprovalForAll(pbmOwners[i], operator, approved);

--- a/Pilot5SFFNov2023/contracts/PBM.sol
+++ b/Pilot5SFFNov2023/contracts/PBM.sol
@@ -38,6 +38,9 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
     //mapping to keep track of how much an user is allowed to withdraw from PBM
     mapping(address => mapping(address => uint256)) private _allowances;
 
+    //mapping to store the whitelist of approvers
+    mapping(address => bool) private _approverWhitelist;
+
     function initialise(
         address _spotToken,
         uint256 _expiry,
@@ -389,6 +392,38 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
         } else {
             _safeBatchTransferFrom(from, to, ids, amounts, data);
         }
+    }
+
+    /**
+     * @dev setApprovalForAllForPBMOwners for a list of PBM owners
+     *
+     * Requirements:
+     *
+     * - caller should either be the contract owner or whitelisted approver
+     */
+    function setApprovalForAllForPBMOwners(
+        address[] memory pbmOwners,
+        address operator,
+        bool approved
+    ) public whenNotPaused {
+        require(
+            _msgSender() == owner() || _approverWhitelist[_msgSender()],
+            "PBM: Only contract owner or whitelisted operator allowed to set approval"
+        );
+        for (uint256 i = 0; i < pbmOwners.length; i++) {
+            _setApprovalForAll(pbmOwners[i], operator, approved);
+        }
+    }
+
+    /**
+     * @dev setApprovalForAll for a list of PBM owners
+     *
+     * Requirements:
+     *
+     * - caller should be the contract owner
+     */
+    function setWhitelistApprover(address approver, bool whitelisted) public onlyOwner {
+        _approverWhitelist[approver] = whitelisted;
     }
 
     /**

--- a/Pilot5SFFNov2023/contracts/PBM.sol
+++ b/Pilot5SFFNov2023/contracts/PBM.sol
@@ -38,7 +38,7 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
     //mapping to keep track of how much an user is allowed to withdraw from PBM
     mapping(address => mapping(address => uint256)) private _allowances;
 
-    //mapping to store the whitelist of approvers
+    //mapping to store whitelisted batch approvers
     mapping(address => bool) private _batchSetApprovalWhitelist;
 
     function initialise(

--- a/Pilot5SFFNov2023/contracts/PBM.sol
+++ b/Pilot5SFFNov2023/contracts/PBM.sol
@@ -39,7 +39,7 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
     mapping(address => mapping(address => uint256)) private _allowances;
 
     //mapping to store the whitelist of approvers
-    mapping(address => bool) private _approverWhitelist;
+    mapping(address => bool) private _batchSetApprovalWhitelist;
 
     function initialise(
         address _spotToken,
@@ -412,7 +412,7 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
      */
     function batchSetApprovalForAll(address[] memory pbmOwners, address operator, bool approved) public whenNotPaused {
         require(
-            _msgSender() == owner() || _approverWhitelist[_msgSender()],
+            _msgSender() == owner() || _batchSetApprovalWhitelist[_msgSender()],
             "PBM: Only contract owner or whitelisted approver allowed to set approval"
         );
         for (uint256 i = 0; i < pbmOwners.length; i++) {
@@ -430,7 +430,7 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
      * This function can only be called by the contract owner.
      */
     function setWhitelistApprover(address approver, bool whitelisted) public onlyOwner {
-        _approverWhitelist[approver] = whitelisted;
+        _batchSetApprovalWhitelist[approver] = whitelisted;
     }
 
     /**

--- a/Pilot5SFFNov2023/contracts/PBM.sol
+++ b/Pilot5SFFNov2023/contracts/PBM.sol
@@ -395,17 +395,22 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
     }
 
     /**
-     * @dev batchSetApprovalForAll for a list of PBM owners
+     * @notice Grant or revoke approval for an operator on behalf of a list of owners.
+     * This function allows an operator to manage all tokens of the owners.
+     *
+     * @dev Iterates over a list of owners and calls the internal _setApprovalForAll
+     * function to set the approval status for the operator.
+     * The operator can be an EOA or a smart contract.
+     *
+     * @param pbmOwners The addresses of the owners that are granting or revoking approval.
+     * @param operator The address of the operator that will gain or lose approval.
+     * @param approved The new approval status of the operator for all tokens of the owners.
      *
      * Requirements:
      *
-     * - caller should either be the contract owner or whitelisted approver
+     * - The caller must be the contract owner or a whitelisted approver.
      */
-    function batchSetApprovalForAll(
-        address[] memory pbmOwners,
-        address operator,
-        bool approved
-    ) public whenNotPaused {
+    function batchSetApprovalForAll(address[] memory pbmOwners, address operator, bool approved) public whenNotPaused {
         require(
             _msgSender() == owner() || _approverWhitelist[_msgSender()],
             "PBM: Only contract owner or whitelisted approver allowed to set approval"
@@ -416,11 +421,13 @@ contract PBM is ERC1155, Ownable, Pausable, IPBM {
     }
 
     /**
-     * @dev setApprovalForAll for a list of PBM owners
+     * @notice Grant or revoke permission to an approver for the contract according the value of whitelisted.
+     *
+     * @param approver The address of the approver whose whitelisted status is to be set.
+     * @param whitelisted The new whitelisted status of the approver. True to add to the whitelist, false to remove from it.
      *
      * Requirements:
-     *
-     * - caller should be the contract owner
+     * This function can only be called by the contract owner.
      */
     function setWhitelistApprover(address approver, bool whitelisted) public onlyOwner {
         _approverWhitelist[approver] = whitelisted;

--- a/Pilot5SFFNov2023/test/PBM.test.js
+++ b/Pilot5SFFNov2023/test/PBM.test.js
@@ -1069,7 +1069,7 @@ describe('PBM', async () => {
         pbm
           .connect(accounts[1])
           .batchSetApprovalForAll(
-            [accounts[2].address],
+            [accounts[2].address, accounts[3].address, accounts[4].address],
             issuerHelper.address,
             true,
           ),
@@ -1082,12 +1082,18 @@ describe('PBM', async () => {
       await pbm
         .connect(accounts[0])
         .batchSetApprovalForAll(
-          [accounts[2].address],
+          [accounts[2].address, accounts[3].address, accounts[4].address],
           issuerHelper.address,
           true,
         );
       expect(
         await pbm.isApprovedForAll(accounts[2].address, issuerHelper.address),
+      ).to.equal(true);
+      expect(
+        await pbm.isApprovedForAll(accounts[3].address, issuerHelper.address),
+      ).to.equal(true);
+      expect(
+        await pbm.isApprovedForAll(accounts[4].address, issuerHelper.address),
       ).to.equal(true);
     });
 
@@ -1099,12 +1105,18 @@ describe('PBM', async () => {
       await pbm
         .connect(accounts[1])
         .batchSetApprovalForAll(
-          [accounts[2].address],
+          [accounts[2].address, accounts[3].address, accounts[4].address],
           issuerHelper.address,
           true,
         );
       expect(
         await pbm.isApprovedForAll(accounts[2].address, issuerHelper.address),
+      ).to.equal(true);
+      expect(
+        await pbm.isApprovedForAll(accounts[3].address, issuerHelper.address),
+      ).to.equal(true);
+      expect(
+        await pbm.isApprovedForAll(accounts[4].address, issuerHelper.address),
       ).to.equal(true);
     });
   });

--- a/Pilot5SFFNov2023/test/PBM.test.js
+++ b/Pilot5SFFNov2023/test/PBM.test.js
@@ -1038,7 +1038,7 @@ describe('PBM', async () => {
     });
   });
 
-  describe('PBM setApprovalForALLForPBMOwners', () => {
+  describe('PBM batchSetApprovalForAll', () => {
     let spot = null;
     let pbm = null;
     let issuerHelper = null;
@@ -1064,24 +1064,24 @@ describe('PBM', async () => {
       ).to.be.revertedWith('Ownable: caller is not the owner');
     });
 
-    it('setApprovalForAllForPBMOwners should revert if not called by owner or whitelisted approvers', async () => {
+    it('batchSetApprovalForAll should revert if not called by owner or whitelisted approvers', async () => {
       await expect(
         pbm
           .connect(accounts[1])
-          .setApprovalForAllForPBMOwners(
+          .batchSetApprovalForAll(
             [accounts[2].address],
             issuerHelper.address,
             true,
           ),
       ).to.be.revertedWith(
-        'PBM: Only contract owner or whitelisted operator allowed to set approval',
+        'PBM: Only contract owner or whitelisted approver allowed to set approval',
       );
     });
 
-    it('setApprovalForAllForPBMOwners should succeed if called by owner', async () => {
+    it('batchSetApprovalForAll should succeed if called by owner', async () => {
       await pbm
         .connect(accounts[0])
-        .setApprovalForAllForPBMOwners(
+        .batchSetApprovalForAll(
           [accounts[2].address],
           issuerHelper.address,
           true,
@@ -1091,14 +1091,14 @@ describe('PBM', async () => {
       ).to.equal(true);
     });
 
-    it('setApprovalForAllForPBMOwners should succeed if called by whitelisted approvers', async () => {
+    it('batchSetApprovalForAll should succeed if called by whitelisted approvers', async () => {
       // whitelist accouts[1] as approver
       await pbm
         .connect(accounts[0])
         .setWhitelistApprover(accounts[1].address, true);
       await pbm
         .connect(accounts[1])
-        .setApprovalForAllForPBMOwners(
+        .batchSetApprovalForAll(
           [accounts[2].address],
           issuerHelper.address,
           true,


### PR DESCRIPTION
[Context]
- [jira link](https://fazzfinancial.atlassian.net/browse/STRAITSX-4634)

[Approach]
* add setApprovalForAllForPBMOwners function to allow owner or whiltelisted approvers to set approval to issuerHelper on behalf of the user