### PR TITLE
[STRAITSX-9355] chore(pending-payment): add pending payment

### DIFF
--- a/NoahPBM/contracts/paymentmanager/NoahPaymentManager.sol
+++ b/NoahPBM/contracts/paymentmanager/NoahPaymentManager.sol
@@ -24,6 +24,16 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
     // Keeps track of pending balances
     mapping(address => mapping(address => uint256)) internal pendingPBMTokenBalance;
 
+    // Pending payment details struct
+    struct PendingPayment {
+        address erc20Token;
+        uint256 erc20TokenValue;
+    }
+
+    // Keeps track of erc20 token value of each unique payment id
+    // paymentUniqueID => erc20TokenValue
+    mapping(string => PendingPayment) internal pendingPaymentList;
+
     bytes32 public constant NOAH_CRAWLER_ROLE = keccak256("NOAH_PAYMENT_CRAWLER");
 
     // tracks contract initialisation
@@ -141,6 +151,12 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
         return pendingPBMTokenBalance[pbmAddress][erc20token] + pbmTokenBalance[pbmAddress][erc20token];
     }
 
+    /// @dev Returns the pending payment details of a paymentUniqueId
+    function getPendingPayment(string memory paymentUniqueId) public view returns (address, uint256) {
+        PendingPayment memory payment = pendingPaymentList[paymentUniqueId];
+        return (payment.erc20Token, payment.erc20TokenValue);
+    }
+
     function _increaseTreasuryBalance(address campaignPBM, address erc20token, uint256 value) internal whenNotPaused {
         require(Address.isContract(campaignPBM), "Invalid PBM contract address");
         require(Address.isContract(erc20token), "Invalid ERC20 contract address");
@@ -206,6 +222,18 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
         emit TreasuryPendingBalanceDecrease(campaignPBM, erc20Token, erc20TokenValue);
     }
 
+    function _addToPendingPaymentList(
+        string memory paymentUniqueId,
+        address erc20Token,
+        uint256 erc20TokenValue
+    ) internal {
+        require(bytes(paymentUniqueId).length != 0, "Payment unique ID cannot be empty");
+        require(Address.isContract(erc20Token), "Must be a valid ERC20 smart contract");
+        require(erc20TokenValue > 0, "token value must be more than 0");
+
+        pendingPaymentList[paymentUniqueId] = PendingPayment(erc20Token, erc20TokenValue);
+    }
+
     /////////////////// INoahPaymentStateMachine functions  //////////////////////////
 
     /// @notice called by campaign PBM to attempt a payment request to a merchant wallet.
@@ -226,9 +254,10 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
         // Ensure that only campaign PBM can spend its own money
         require(pbmTokenBalance[campaignPBM][erc20Token] >= erc20TokenValue, "ERC20: transfer amount exceeds balance");
 
-        require(bytes(paymentUniqueId).length != 0);
+        require(bytes(paymentUniqueId).length != 0, "Payment unique ID cannot be empty");
 
         _markPendingTreasuryBalance(campaignPBM, erc20Token, erc20TokenValue);
+        _addToPendingPaymentList(paymentUniqueId, erc20Token, erc20TokenValue);
 
         // Inform Oracle to make payments
         emit MerchantPaymentCreated(campaignPBM, from, to, erc20Token, erc20TokenValue, paymentUniqueId, metadata);
@@ -261,6 +290,8 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
 
         // ERC20 token movement: Disburse the custodied ERC20 tokens from this smart contract to destination.
         ERC20Helper.safeTransfer(erc20Token, to, erc20TokenValue);
+        // Set the pending payment value to 0 to mark paymentUniqueId as completed
+        pendingPaymentList[paymentUniqueId].erc20TokenValue = 0;
 
         emit MerchantPaymentCompleted(campaignPBM, from, to, erc20Token, erc20TokenValue, paymentUniqueId, metadata);
     }
@@ -276,25 +307,36 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
         address campaignPBM,
         address from,
         address to,
-        address erc20Token,
-        uint256 erc20TokenValue,
         string memory paymentUniqueId,
         bytes memory metadata
     ) public whenNotPaused {
         require(hasRole(NOAH_CRAWLER_ROLE, _msgSender()));
         require(Address.isContract(campaignPBM), "Must be a valid smart contract");
-        require(Address.isContract(erc20Token), "Must be a valid ERC20 smart contract");
-        require(erc20TokenValue > 0, "Token value should be more than 0");
-        require(bytes(paymentUniqueId).length != 0);
+        require(bytes(paymentUniqueId).length != 0, "Payment unique ID cannot be empty");
+
+        // Retrieve the pending payment details
+        PendingPayment memory payment = pendingPaymentList[paymentUniqueId];
+        require(Address.isContract(payment.erc20Token), "Must be a valid ERC20 smart contract");
+        require(payment.erc20TokenValue > 0, "Token value should be more than 0");
 
         // [TODO] inform campaign pbm to emit payment cancel. no money movement has occured
         // [TODO] inform campaign pbm to refund PBM back to user.
 
         // Ensure funds are re-credited back
-        _revertPendingTreasuryBalance(campaignPBM, erc20Token, erc20TokenValue);
+        _revertPendingTreasuryBalance(campaignPBM, payment.erc20Token, payment.erc20TokenValue);
+        // Set the pending payment value to 0 to mark paymentUniqueId as refunded
+        pendingPaymentList[paymentUniqueId].erc20TokenValue = 0;
 
         // Emit payment cancel for accounting purposes
-        emit MerchantPaymentCancelled(campaignPBM, from, to, erc20Token, erc20TokenValue, paymentUniqueId, metadata);
+        emit MerchantPaymentCancelled(
+            campaignPBM,
+            from,
+            to,
+            payment.erc20Token,
+            payment.erc20TokenValue,
+            paymentUniqueId,
+            metadata
+        );
     }
 
     // Called by noah servers to refund a payment.

--- a/NoahPBM/contracts/paymentmanager/NoahPaymentManager.sol
+++ b/NoahPBM/contracts/paymentmanager/NoahPaymentManager.sol
@@ -284,7 +284,7 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
 
         require(
             pendingPBMTokenBalance[campaignPBM][payment.erc20Token] >= payment.erc20TokenValue,
-            "ERC20: transfer amount exceeds balance"
+            "ERC20: payment transfer amount exceeds available pending balance"
         );
 
         // Update internal balance sheet
@@ -292,6 +292,9 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
 
         // ERC20 token movement: Disburse the custodied ERC20 tokens from this smart contract to destination.
         ERC20Helper.safeTransfer(payment.erc20Token, to, payment.erc20TokenValue);
+
+        // Set the pending payment value to 0 to mark paymentUniqueId as completed
+        pendingPaymentList[paymentUniqueId].erc20TokenValue = 0;
 
         emit MerchantPaymentCompleted(
             campaignPBM,
@@ -302,9 +305,6 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
             paymentUniqueId,
             metadata
         );
-
-        // Set the pending payment value to 0 to mark paymentUniqueId as completed
-        pendingPaymentList[paymentUniqueId].erc20TokenValue = 0;
     }
 
     /**
@@ -333,6 +333,9 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
         // [TODO] inform campaign pbm to emit payment cancel. no money movement has occured
         // [TODO] inform campaign pbm to refund PBM back to user.
 
+        // Set the pending payment value to 0 to mark paymentUniqueId as cancelled
+        pendingPaymentList[paymentUniqueId].erc20TokenValue = 0;
+
         // Ensure funds are re-credited back
         _revertPendingTreasuryBalance(campaignPBM, payment.erc20Token, payment.erc20TokenValue);
 
@@ -346,9 +349,6 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
             paymentUniqueId,
             metadata
         );
-
-        // Set the pending payment value to 0 to mark paymentUniqueId as cancelled
-        pendingPaymentList[paymentUniqueId].erc20TokenValue = 0;
     }
 
     // Called by noah servers to refund a payment.

--- a/NoahPBM/contracts/pbm/PBMPayment.sol
+++ b/NoahPBM/contracts/pbm/PBMPayment.sol
@@ -214,7 +214,7 @@ contract PBMPayment is ERC1155, Ownable, Pausable, IPBM {
         NoahPaymentManager(noahPaymentManager).createPayment(from, to, spotToken, valueOfTokens, paymentUniqueId, data);
 
         // Burn PBM ERC1155 Tokens
-        _burn(_msgSender(), id, amount);
+        _burn(from, id, amount);
         PBMTokenManager(pbmTokenManager).decreaseBalanceSupply(serialise(id), serialise(amount));
 
         emit MerchantPayment(from, to, serialise(id), serialise(amount), spotToken, valueOfTokens);

--- a/NoahPBM/hardhat.config.js
+++ b/NoahPBM/hardhat.config.js
@@ -105,7 +105,7 @@ module.exports = {
       network_id: 43113,
       saveDeployments: true,
       deploy: ["deploy/"],
-      tags: ["ruji"],
+      tags: ["fuji"],
     },
     avax: {
       accounts: [Wallet.fromMnemonic(process.env.DEPLOYER_MNEMONIC).privateKey],
@@ -121,6 +121,7 @@ module.exports = {
       polygon: POLYGON_SCAN_API_KEY,
       sepolia: process.env.SEPOLIA_SCAN_API_KEY,
       holesky: process.env.ETHER_SCAN_API_KEY,
+      fuji: "fuji",
     },
     customChains: [
       {
@@ -145,6 +146,15 @@ module.exports = {
         urls: {
           apiURL: "https://api-holesky.etherscan.io/api",
           browserURL: "https://holesky.etherscan.io/",
+        },
+      },
+      {
+        network: "fuji",
+        chainId: 43113,
+        urls: {
+          apiURL:
+              "https://api.routescan.io/v2/network/testnet/evm/43113/etherscan",
+          browserURL: "https://c-chain.snowtrace.io",
         },
       },
     ],

--- a/NoahPBM/test/paymentpbm/noahManager.test.js
+++ b/NoahPBM/test/paymentpbm/noahManager.test.js
@@ -184,15 +184,7 @@ describe("Noah Payment Manager Test", () => {
         .grantRole(noahPaymentManager.NOAH_CRAWLER_ROLE(), noahCrawler.address);
       await noahPaymentManager
         .connect(noahCrawler)
-        .completePayment(
-          pbm.address,
-          aliOmnibus.address,
-          merchant.address,
-          xsgdToken.address,
-          parseUnits("500", await xsgdToken.decimals()),
-          "unique_payment_id",
-          "0x"
-        );
+        .completePayment(pbm.address, aliOmnibus.address, merchant.address, "unique_payment_id", "0x");
       // Check if pending payment is removed
       const completedPayment = await noahPaymentManager.getPendingPayment("unique_payment_id");
       expect(completedPayment[0]).to.equal(xsgdToken.address);
@@ -286,15 +278,7 @@ describe("Noah Payment Manager Test", () => {
         .grantRole(noahPaymentManager.NOAH_CRAWLER_ROLE(), noahCrawler.address);
       await noahPaymentManager
         .connect(noahCrawler)
-        .completePayment(
-          pbm.address,
-          aliOmnibus.address,
-          merchant.address,
-          xsgdToken.address,
-          parseUnits("500", await xsgdToken.decimals()),
-          "unique_payment_id",
-          "0x"
-        );
+        .completePayment(pbm.address, aliOmnibus.address, merchant.address, "unique_payment_id", "0x");
 
       expect(await noahPaymentManager.getPBMCampaignTreasuryBalance(pbm.address, xsgdToken.address)).to.equal(0);
       expect(await xsgdToken.balanceOf(noahPaymentManager.address)).to.equal(0);


### PR DESCRIPTION
This PR contains following changes:
1. add a `pendingPaymentList` data structure with a `pendingPayment` struct.
2. retrieve payment details from `pendingPaymentList` data structure so that we can be sure payment details are correct.
3. fix a bug when burn the erc1155 upon requesting payment it should burn from the `from` address instead of msgSender. because in the grab use case the msg sender of the `requestPayment` function would be the master wallet but when burning the erc1155 token it needs to burn from user wallet the `from` address
4. add happy flow test cases for grab use case

next PR will cover the cancel and refund implementation 