### PR TITLE
[STRAITSX-10969] feat(noahManager): hashed payment unique id

### DIFF
--- a/NoahPBM/abi/PBMPayment.json
+++ b/NoahPBM/abi/PBMPayment.json
@@ -653,7 +653,7 @@
       },
       {
         "internalType": "string",
-        "name": "paymentUniqueId",
+        "name": "sourceReferenceID",
         "type": "string"
       },
       {
@@ -691,7 +691,7 @@
       },
       {
         "internalType": "string",
-        "name": "paymentUniqueId",
+        "name": "sourceReferenceID",
         "type": "string"
       },
       {

--- a/NoahPBM/contracts/paymentmanager/INoahPaymentStateMachine.sol
+++ b/NoahPBM/contracts/paymentmanager/INoahPaymentStateMachine.sol
@@ -44,22 +44,22 @@ interface INoahPaymentStateMachine {
     /// 3. NFT metadata for airdrops
     event MerchantPaymentCreated(
         address indexed campaignPBM,
-        address from,
+        address indexed from,
         address indexed to,
         address ERC20Token,
         uint256 ERC20TokenValue,
-        string indexed sourceReferenceID,
+        string sourceReferenceID,
         bytes metadata
     );
 
     /// @notice Emitted when a payment is successfully done and acknowledged by acquirer.
     event MerchantPaymentCompleted(
         address indexed campaignPBM,
-        address from,
+        address indexed from,
         address indexed to,
         address ERC20Token,
         uint256 ERC20TokenValue,
-        string indexed sourceReferenceID,
+        string sourceReferenceID,
         bytes metadata
     );
 
@@ -68,11 +68,11 @@ interface INoahPaymentStateMachine {
     /// in order to update their users on a payment cancellation event.
     event MerchantPaymentCancelled(
         address indexed campaignPBM,
-        address from,
+        address indexed from,
         address indexed to,
         address ERC20Token,
         uint256 ERC20TokenValue,
-        string indexed sourceReferenceID,
+        string sourceReferenceID,
         bytes metadata
     );
 
@@ -80,11 +80,11 @@ interface INoahPaymentStateMachine {
     event MerchantPaymentRefunded(
         address indexed campaignPBM,
         address indexed from,
-        address to,
+        address indexed to,
         address ERC20Token,
         uint256 ERC20TokenValue,
         string sourceReferenceID,
-        string indexed refundUniqueId,
+        string refundUniqueId,
         bytes metadata
     );
 

--- a/NoahPBM/contracts/paymentmanager/INoahPaymentStateMachine.sol
+++ b/NoahPBM/contracts/paymentmanager/INoahPaymentStateMachine.sol
@@ -43,23 +43,23 @@ interface INoahPaymentStateMachine {
     /// ie: Get a USDC<>XSGD quote from STX, pay in USDC and indicate quote ref here
     /// 3. NFT metadata for airdrops
     event MerchantPaymentCreated(
-        address campaignPBM,
+        address indexed campaignPBM,
         address from,
-        address to,
+        address indexed to,
         address ERC20Token,
         uint256 ERC20TokenValue,
-        string sourceReferenceID,
+        string indexed sourceReferenceID,
         bytes metadata
     );
 
     /// @notice Emitted when a payment is successfully done and acknowledged by acquirer.
     event MerchantPaymentCompleted(
-        address campaignPBM,
+        address indexed campaignPBM,
         address from,
-        address to,
+        address indexed to,
         address ERC20Token,
         uint256 ERC20TokenValue,
-        string sourceReferenceID,
+        string indexed sourceReferenceID,
         bytes metadata
     );
 
@@ -67,24 +67,24 @@ interface INoahPaymentStateMachine {
     /// Campaign PBM should be notified as well when this occurs. Wallet issuers should subscribe to this event
     /// in order to update their users on a payment cancellation event.
     event MerchantPaymentCancelled(
-        address campaignPBM,
+        address indexed campaignPBM,
         address from,
-        address to,
+        address indexed to,
         address ERC20Token,
         uint256 ERC20TokenValue,
-        string sourceReferenceID,
+        string indexed sourceReferenceID,
         bytes metadata
     );
 
     /// @notice Emitted  when merchant initiates a refund back to a user / wallet issuer.
     event MerchantPaymentRefunded(
-        address campaignPBM,
-        address from,
+        address indexed campaignPBM,
+        address indexed from,
         address to,
         address ERC20Token,
         uint256 ERC20TokenValue,
         string sourceReferenceID,
-        string refundUniqueId,
+        string indexed refundUniqueId,
         bytes metadata
     );
 
@@ -96,9 +96,9 @@ interface INoahPaymentStateMachine {
      *  This is for wallet issuers that are unable to sign raw transactions and can only rely on the ERC1155 safeTransfer mechanism.
      */
     event MerchantPaymentDirect(
-        address campaignPBM,
-        address from,
-        address to,
+        address indexed campaignPBM,
+        address indexed from,
+        address indexed to,
         address ERC20Token,
         uint256 ERC20TokenValue,
         bytes metadata

--- a/NoahPBM/contracts/paymentmanager/NoahPaymentManager.sol
+++ b/NoahPBM/contracts/paymentmanager/NoahPaymentManager.sol
@@ -31,7 +31,7 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
     }
 
     // Keeps track of erc20 token value of each paymentUniqueID
-    // paymentUniqueID is a keccak256 hash of campaignPBM address and sourceReferenceID
+    // paymentUniqueID is a keccak256 hash of from address and sourceReferenceID
     // paymentUniqueID => PendingPayment
     mapping(bytes32 => PendingPayment) internal pendingPaymentList;
 
@@ -153,9 +153,9 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
     }
 
     /// @dev Returns the pending payment details of a sourceReferenceID
-    function getPendingPayment(address campaignPBM, string memory sourceReferenceID) public view returns (address, uint256) {
+    function getPendingPayment(address from, string memory sourceReferenceID) public view returns (address, uint256) {
         // Generate the unique payment ID
-        bytes32 paymentUniqueID = _generatePaymentUniqueID(campaignPBM, sourceReferenceID);
+        bytes32 paymentUniqueID = _generatePaymentUniqueID(from, sourceReferenceID);
         PendingPayment memory payment = pendingPaymentList[paymentUniqueID];
         return (payment.erc20Token, payment.erc20TokenValue);
     }
@@ -225,8 +225,8 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
         emit TreasuryPendingBalanceDecrease(campaignPBM, erc20Token, erc20TokenValue);
     }
 
-    function _generatePaymentUniqueID(address campaignPBM, string memory sourceReferenceID) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(campaignPBM, sourceReferenceID));
+    function _generatePaymentUniqueID(address from, string memory sourceReferenceID) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(from, sourceReferenceID));
     }
 
     function _addToPendingPaymentList(bytes32 paymentUniqueID, address erc20Token, uint256 erc20TokenValue) internal {
@@ -262,8 +262,8 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
 
         require(bytes(sourceReferenceID).length != 0, "Source Reference ID cannot be empty");
 
-        // Generate the unique payment ID from campaignPBM and sourceReferenceID
-        bytes32 paymentUniqueID = _generatePaymentUniqueID(campaignPBM, sourceReferenceID);
+        // Generate the unique payment ID from from address and sourceReferenceID
+        bytes32 paymentUniqueID = _generatePaymentUniqueID(from, sourceReferenceID);
         // Check whether the uniquePaymentID already exists in pendingPaymentList
         require(pendingPaymentList[paymentUniqueID].erc20TokenValue == 0, "Payment request already exists");
 
@@ -288,8 +288,8 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
         require(Address.isContract(campaignPBM), "Must be a valid smart contract");
         require(bytes(sourceReferenceID).length != 0, "Source Reference ID cannot be empty");
 
-        // Generate the unique payment ID from campaignPBM and sourceReferenceID
-        bytes32 paymentUniqueID = _generatePaymentUniqueID(campaignPBM, sourceReferenceID);
+        // Generate the unique payment ID from from address and sourceReferenceID
+        bytes32 paymentUniqueID = _generatePaymentUniqueID(from, sourceReferenceID);
 
         // Retrieve the pending payment details
         PendingPayment memory payment = pendingPaymentList[paymentUniqueID];
@@ -339,8 +339,8 @@ contract NoahPaymentManager is Ownable, Pausable, AccessControl, INoahPaymentSta
         require(Address.isContract(campaignPBM), "Must be a valid smart contract");
         require(bytes(sourceReferenceID).length != 0, "Source Reference ID cannot be empty");
 
-        // Generate the unique payment ID from campaignPBM and sourceReferenceID
-        bytes32 paymentUniqueID = _generatePaymentUniqueID(campaignPBM, sourceReferenceID);
+        // Generate the unique payment ID from from address and sourceReferenceID
+        bytes32 paymentUniqueID = _generatePaymentUniqueID(from, sourceReferenceID);
 
         // Retrieve the pending payment details
         PendingPayment memory payment = pendingPaymentList[paymentUniqueID];

--- a/NoahPBM/contracts/pbm/PBMPayment.sol
+++ b/NoahPBM/contracts/pbm/PBMPayment.sol
@@ -188,7 +188,7 @@ contract PBMPayment is ERC1155, Ownable, Pausable, IPBM {
      * @param to PBM payment address. Must be a merchant address.
      * @param id PBM Token Id
      * @param amount Number of PBM to send
-     * @param paymentUniqueId payment unique identifier.
+     * @param sourceReferenceID payment source unique identifier.
      * Must be guaranteed to be unique globally across all chains to allow oracle fallback to another
      * chain if necessary
      * @param data metadata to include
@@ -198,7 +198,7 @@ contract PBMPayment is ERC1155, Ownable, Pausable, IPBM {
         address to,
         uint256 id,
         uint256 amount,
-        string memory paymentUniqueId,
+        string memory sourceReferenceID,
         bytes memory data
     ) external whenNotPaused {
         _validateTransfer(from, to);
@@ -211,7 +211,7 @@ contract PBMPayment is ERC1155, Ownable, Pausable, IPBM {
 
         // Initiate payment of ERC20 tokens
         address spotToken = getSpotAddress(id);
-        NoahPaymentManager(noahPaymentManager).createPayment(from, to, spotToken, valueOfTokens, paymentUniqueId, data);
+        NoahPaymentManager(noahPaymentManager).createPayment(from, to, spotToken, valueOfTokens, sourceReferenceID, data);
 
         // Burn PBM ERC1155 Tokens
         _burn(from, id, amount);
@@ -229,7 +229,7 @@ contract PBMPayment is ERC1155, Ownable, Pausable, IPBM {
         address to,
         uint256[] memory ids,
         uint256[] memory amounts,
-        string memory paymentUniqueId,
+        string memory sourceReferenceID,
         bytes memory data
     ) external whenNotPaused {
         _validateTransfer(from, to);
@@ -270,7 +270,7 @@ contract PBMPayment is ERC1155, Ownable, Pausable, IPBM {
                 to,
                 commonTokenAddress,
                 sumOfTokens,
-                paymentUniqueId,
+                sourceReferenceID,
                 data
             );
 

--- a/NoahPBM/test/paymentpbm/noahManager.test.js
+++ b/NoahPBM/test/paymentpbm/noahManager.test.js
@@ -154,7 +154,7 @@ describe("Noah Payment Manager Test", () => {
         .connect(aliOmnibus)
         .requestPayment(aliOmnibus.address, merchant.address, 0, 500, "unique_payment_id", "0x");
 
-      const pendingPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
+      const pendingPayment = await noahPaymentManager.getPendingPayment(aliOmnibus.address, "unique_payment_id");
       expect(pendingPayment[0]).to.equal(xsgdToken.address);
       expect(pendingPayment[1]).to.equal(parseUnits("500", await xsgdToken.decimals()));
     });
@@ -172,7 +172,7 @@ describe("Noah Payment Manager Test", () => {
           .connect(aliOmnibus)
           .requestPayment(aliOmnibus.address, merchant.address, 0, 500, "unique_payment_id", "0x");
 
-      const pendingPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
+      const pendingPayment = await noahPaymentManager.getPendingPayment(aliOmnibus.address, "unique_payment_id");
       expect(pendingPayment[0]).to.equal(xsgdToken.address);
       expect(pendingPayment[1]).to.equal(parseUnits("500", await xsgdToken.decimals()));
 
@@ -195,7 +195,7 @@ describe("Noah Payment Manager Test", () => {
         .connect(aliOmnibus)
         .requestPayment(aliOmnibus.address, merchant.address, 0, 500, "unique_payment_id", "0x");
 
-      const pendingPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
+      const pendingPayment = await noahPaymentManager.getPendingPayment(aliOmnibus.address, "unique_payment_id");
       expect(pendingPayment[0]).to.equal(xsgdToken.address);
       expect(pendingPayment[1]).to.equal(parseUnits("500", await xsgdToken.decimals()));
 
@@ -207,7 +207,7 @@ describe("Noah Payment Manager Test", () => {
         .connect(noahCrawler)
         .completePayment(pbm.address, aliOmnibus.address, merchant.address, "unique_payment_id", "0x");
       // Check if pending payment is removed
-      const completedPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
+      const completedPayment = await noahPaymentManager.getPendingPayment(aliOmnibus.address, "unique_payment_id");
       expect(completedPayment[0]).to.equal(xsgdToken.address);
       expect(completedPayment[1]).to.equal(0);
     });
@@ -227,7 +227,7 @@ describe("Noah Payment Manager Test", () => {
         .connect(aliOmnibus)
         .requestPayment(aliOmnibus.address, merchant.address, 0, 500, "unique_payment_id", "0x");
 
-      const pendingPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
+      const pendingPayment = await noahPaymentManager.getPendingPayment(aliOmnibus.address, "unique_payment_id");
       expect(pendingPayment[0]).to.equal(xsgdToken.address);
       expect(pendingPayment[1]).to.equal(parseUnits("500", await xsgdToken.decimals()));
 
@@ -240,7 +240,7 @@ describe("Noah Payment Manager Test", () => {
         .cancelPayment(pbm.address, aliOmnibus.address, merchant.address, "unique_payment_id", "0x");
 
       // Check if pending payment is removed
-      const cancelledPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
+      const cancelledPayment = await noahPaymentManager.getPendingPayment(aliOmnibus.address, "unique_payment_id");
       expect(cancelledPayment[0]).to.equal(xsgdToken.address);
       expect(cancelledPayment[1]).to.equal(0);
     });

--- a/NoahPBM/test/paymentpbm/noahManager.test.js
+++ b/NoahPBM/test/paymentpbm/noahManager.test.js
@@ -154,9 +154,30 @@ describe("Noah Payment Manager Test", () => {
         .connect(aliOmnibus)
         .requestPayment(aliOmnibus.address, merchant.address, 0, 500, "unique_payment_id", "0x");
 
-      const pendingPayment = await noahPaymentManager.getPendingPayment("unique_payment_id");
+      const pendingPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
       expect(pendingPayment[0]).to.equal(xsgdToken.address);
       expect(pendingPayment[1]).to.equal(parseUnits("500", await xsgdToken.decimals()));
+    });
+
+    it("Should ensure payments can only be created if sourceReferenceID is unique for each pbmCampaign contract", async () => {
+      const merchant = accounts[3];
+      const aliOmnibus = accounts[4];
+      await xsgdToken.mint(aliOmnibus.address, parseUnits("10000", await xsgdToken.decimals()));
+
+      await addressList.addMerchantAddresses([merchant.address], "");
+      await xsgdToken.connect(aliOmnibus).increaseAllowance(pbm.address, parseUnits("1000", await xsgdToken.decimals()));
+      await pbm.connect(aliOmnibus).mint(0, 1000, aliOmnibus.address);
+
+      await pbm
+          .connect(aliOmnibus)
+          .requestPayment(aliOmnibus.address, merchant.address, 0, 500, "unique_payment_id", "0x");
+
+      const pendingPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
+      expect(pendingPayment[0]).to.equal(xsgdToken.address);
+      expect(pendingPayment[1]).to.equal(parseUnits("500", await xsgdToken.decimals()));
+
+      // Request payment with same sourceReferenceID should fail
+      await expect(pbm.connect(aliOmnibus).requestPayment(aliOmnibus.address, merchant.address, 0, 500, "unique_payment_id", "0x")).to.be.revertedWith("Payment request already exists");
     });
 
     it("Should ensure a pending payment is removed from pendingPaymentList when completed a payment", async () => {
@@ -174,7 +195,7 @@ describe("Noah Payment Manager Test", () => {
         .connect(aliOmnibus)
         .requestPayment(aliOmnibus.address, merchant.address, 0, 500, "unique_payment_id", "0x");
 
-      const pendingPayment = await noahPaymentManager.getPendingPayment("unique_payment_id");
+      const pendingPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
       expect(pendingPayment[0]).to.equal(xsgdToken.address);
       expect(pendingPayment[1]).to.equal(parseUnits("500", await xsgdToken.decimals()));
 
@@ -186,7 +207,7 @@ describe("Noah Payment Manager Test", () => {
         .connect(noahCrawler)
         .completePayment(pbm.address, aliOmnibus.address, merchant.address, "unique_payment_id", "0x");
       // Check if pending payment is removed
-      const completedPayment = await noahPaymentManager.getPendingPayment("unique_payment_id");
+      const completedPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
       expect(completedPayment[0]).to.equal(xsgdToken.address);
       expect(completedPayment[1]).to.equal(0);
     });
@@ -206,7 +227,7 @@ describe("Noah Payment Manager Test", () => {
         .connect(aliOmnibus)
         .requestPayment(aliOmnibus.address, merchant.address, 0, 500, "unique_payment_id", "0x");
 
-      const pendingPayment = await noahPaymentManager.getPendingPayment("unique_payment_id");
+      const pendingPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
       expect(pendingPayment[0]).to.equal(xsgdToken.address);
       expect(pendingPayment[1]).to.equal(parseUnits("500", await xsgdToken.decimals()));
 
@@ -219,7 +240,7 @@ describe("Noah Payment Manager Test", () => {
         .cancelPayment(pbm.address, aliOmnibus.address, merchant.address, "unique_payment_id", "0x");
 
       // Check if pending payment is removed
-      const cancelledPayment = await noahPaymentManager.getPendingPayment("unique_payment_id");
+      const cancelledPayment = await noahPaymentManager.getPendingPayment(pbm.address, "unique_payment_id");
       expect(cancelledPayment[0]).to.equal(xsgdToken.address);
       expect(cancelledPayment[1]).to.equal(0);
     });


### PR DESCRIPTION
### What does this PR do 

1. update function param name to `sourceReferenceID`

2. use keccak256 hash of `campaignPBM` address and `sourceReferenceID` as the `pendingPaymentList` mapping key (new `paymentUniqueID`).   

**NOTE**: initially wanted to use hash of `from` and `sourceReferenceID` but it won't work for grab use case because `from` will be individual grab user wallet hence the hashed result will be different for different user with the same `sourceRefereneceID`.

3. add unique check for the hashed key `paymentUniqueID`

4. add indexed fields in the events for easier log filtering.

### To be discussed

1. does the indexed field make sense?

### TODO (will be included in the next PR)

- [ ] document the design and implementation (WIP)
- [ ] cancel and refund implementation (ready to create PR)
- [ ] more test cases (WIP)
- [ ] proxy (WIP)